### PR TITLE
Fix link for kubectl logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ kubectl get svc  -o wide --show-labels --all-namespaces
   * Worker Nodes
     * /var/log/kubelet.log - Kubelet, responsible for running containers on the node
     * /var/log/kube-proxy.log - Kube Proxy, responsible for service load balancing
-* [Manage application logs](https://kubernetes.io/docs/user-guide/kubectl/v1.6/#logs)
+* [Manage application logs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs)
 
 ## Tips:
 


### PR DESCRIPTION
The existing link is broken (and is old too)