### PR TITLE
Updated Kubernetes version that A Cloud Guru course supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ complete -F __start_kubectl k
 
 - [Mumshad CKA with practice tests and mock exams](https://www.udemy.com/course/certified-kubernetes-administrator-with-practice-tests/) - Highly recommended
 - [Killer.sh CKA simulator](https://killer.sh/cka)         &#x27F9; use code **walidshaari** for **20%** discount  - they update frequently
-- [A Cloud Guru - Certified Kubernetes Administrator (CKA)](https://acloud.guru/overview/certified-kubernetes-administrator)  # k8s version 1.19 - last checked January 2021
+- [A Cloud Guru - Certified Kubernetes Administrator (CKA)](https://acloud.guru/overview/certified-kubernetes-administrator)  # k8s version 1.20 - last checked March 2021
 - [LinuxAcademy/ACloudGuru CKA course](https://acloud.guru/learn/7f5137aa-2d26-4b19-8d8c-025b22667e76)  # labs last checked were updated to 1.18
 - [rx-m online CKA course](https://rx-m.com/cka-online-training/)
 - [Pluralsight CKA course](https://www.pluralsight.com/paths/certified-kubernetes-administrator)

--- a/README.md
+++ b/README.md
@@ -281,5 +281,5 @@ complete -F __start_kubectl k
 
 ## Stargazers over time
 
-[![Stargazers over time](https://starchart.cc/walidshaari/Kubernetes-Certified-Administrator.svg)](https://starchart.cc/walidshaari/Kubernetes-Certified-Administrator/)
+[![Stargazers over time](https://starchart.cc/walidshaari/Kubernetes-Certified-Administrator.svg)](https://starchart.cc/walidshaari/Kubernetes-Certified-Administrator)
 


### PR DESCRIPTION
Hi, Thank you for sharing awesome information 👍

I send you some minor update.

At first, A Cloud Guru course already supported Kubernetes `v1.20`. This is log for my account.
So I updated version information.

```sh
$ cloud_user@k8s-control:~$ kubectl get nodes
NAME          STATUS   ROLES                  AGE     VERSION
k8s-control   Ready    control-plane,master   2m41s   v1.20.1
k8s-worker1   Ready    <none>                 2m12s   v1.20.1
```

Second, when we click starchart image `404 page not found` displayed.
So I updated URL (deleted trailing slash).

Thank you!